### PR TITLE
Added getSymbols method, fixed typo

### DIFF
--- a/src/Hitbtc/PublicClient.php
+++ b/src/Hitbtc/PublicClient.php
@@ -43,8 +43,13 @@ class PublicClient
         return json_decode($this->getHttpClient()->get('/api/1/public/ticker')->getBody(), true);
     }
    
-    public function getOderBook($ticker)
+    public function getOrderBook($ticker)
     {
         return json_decode($this->getHttpClient()->get('/api/1/public/'.$ticker.'/orderbook')->getBody(), true);
+    }
+    
+    public function getSymbols()
+    {
+        return json_decode($this->getHttpClient()->get('/api/1/public/symbols')->getBody(), true);
     }
 }


### PR DESCRIPTION
- added method getSymbols, it's in the API docs
- fixed typo, getOrderBook instead of getOderBook